### PR TITLE
refactor: simplify renovate configuration and increase stability period

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,6 @@
     'config:best-practices',
     ':label(renovate)',
     ':timezone(Asia/Tokyo)',
-    'security:openssf-scorecard',
     'schedule:monthly',
   ],
   ignorePresets: [
@@ -16,8 +15,9 @@
     ],
     automerge: false,
   },
-  minimumReleaseAge: '7 days',
+  minimumReleaseAge: '14 days',
   configMigration: true,
+
   packageRules: [
     {
       // 3rd party action の digest を固定する
@@ -30,94 +30,6 @@
         '!korosuke613/{/,}**',
         '!cybozu/{/,}**',
       ],
-    },
-    // npm
-    {
-      // devDependencies は自動更新する
-      matchManagers: [
-        'npm',
-      ],
-      matchDepTypes: [
-        'devDependencies',
-      ],
-      semanticCommitScope: 'deps-dev',
-      automerge: true,
-    },
-    {
-      // @types はプルリクエストをまとめる
-      matchManagers: [
-        'npm',
-      ],
-      matchDepTypes: [
-        'devDependencies',
-      ],
-      semanticCommitScope: 'deps-dev',
-      automerge: true,
-      groupName: 'npm-types',
-      matchPackageNames: [
-        '/^@types/*/',
-      ],
-    },
-    {
-      // linter はプルリクエストをまとめる
-      matchManagers: [
-        'npm',
-      ],
-      matchDepTypes: [
-        'devDependencies',
-      ],
-      groupName: 'npm-linters',
-      automerge: true,
-      matchPackageNames: [
-        '/^eslint/',
-        '/^eslint-*/',
-        '/^@typescript-eslint/*/',
-        '/^prettier/',
-        '/^prettier-*/',
-      ],
-    },
-    // node
-    {
-      // Node.js のマイナー、パッチリリースは自動更新する
-      matchManagers: [
-        'nodenv',
-      ],
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
-      automerge: true,
-    },
-    {
-      // asdf
-      matchManagers: [
-        'asdf',
-      ],
-      matchDatasources: [
-        'node-version',
-      ],
-      matchDepNames: [
-        'node',
-      ],
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
-      automerge: true,
-    },
-    {
-      // npm version のマイナー、パッチリリースは自動更新する
-      matchManagers: [
-        'npm',
-      ],
-      matchDepTypes: [
-        'packageManager',
-      ],
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
-      automerge: true,
     },
   ],
 }


### PR DESCRIPTION
- Remove security:openssf-scorecard preset
- Increase minimumReleaseAge from 7 to 14 days for better stability
- Remove npm-specific package rules to simplify configuration
- Remove Node.js automerge rules to reduce automation complexity

🤖 Generated with [Claude Code](https://claude.ai/code)