### PR TITLE
chore: improve renovate dry-run workflow with direct npx execution

### DIFF
--- a/.github/workflows/renovate-dry-run.yaml
+++ b/.github/workflows/renovate-dry-run.yaml
@@ -21,6 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cybozu/renovate-dry-run-action@v2
-        with:
-          config-file: renovate.json5
+      - env:
+          LOG_LEVEL: debug
+          RENOVATE_DRY_RUN: full
+        run: |
+          # ref: https://docs.renovatebot.com/modules/platform/local/
+          npx -y renovate --platform=local | tee ${{ runner.temp }}/renovate.log
+      - name: Output logs to GITHUB_STEP_SUMMARY
+        if: always()
+        run: |
+          echo "## Renovate Dry Run Logs" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`log" >> $GITHUB_STEP_SUMMARY
+          cat renovate.log >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Replace cybozu/renovate-dry-run-action with direct npx renovate execution
- Add comprehensive logging with GITHUB_STEP_SUMMARY output
- Include reference to Renovate local platform documentation
- Enable debug logging for better troubleshooting

🤖 Generated with [Claude Code](https://claude.ai/code)