### PR TITLE
chore: convert renovate.json5 to JSONC syntax

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "*.json5": "jsonc"
+  }
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,35 +1,35 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    'config:best-practices',
-    ':label(renovate)',
-    ':timezone(Asia/Tokyo)',
-    'schedule:monthly',
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    ":label(renovate)",
+    ":timezone(Asia/Tokyo)",
+    "schedule:monthly"
   ],
-  ignorePresets: [
-    'helpers:pinGitHubActionDigests',
+  "ignorePresets": [
+    "helpers:pinGitHubActionDigests"
   ],
-  vulnerabilityAlerts: {
-    labels: [
-      'security',
+  "vulnerabilityAlerts": {
+    "labels": [
+      "security"
     ],
-    automerge: false,
+    "automerge": false
   },
-  minimumReleaseAge: '14 days',
-  configMigration: true,
+  "minimumReleaseAge": "14 days",
+  "configMigration": true,
 
-  packageRules: [
+  "packageRules": [
     {
       // 3rd party action の digest を固定する
-      matchDepTypes: [
-        'action',
+      "matchDepTypes": [
+        "action"
       ],
-      pinDigests: true,
-      matchPackageNames: [
-        '!actions/{/,}**',
-        '!korosuke613/{/,}**',
-        '!cybozu/{/,}**',
-      ],
-    },
-  ],
+      "pinDigests": true,
+      "matchPackageNames": [
+        "!actions/{/,}**",
+        "!korosuke613/{/,}**",
+        "!cybozu/{/,}**"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
- Update property names to use double quotes for JSONC compliance
- Convert single quotes to double quotes for string values
- Remove trailing commas that could interfere with comments
- Maintain all existing configuration and comments

🤖 Generated with [Claude Code](https://claude.ai/code)